### PR TITLE
Add Windows 10 & Visual Studio 2019 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
     message(WARNING "The file conanbuildinfo.cmake doesn't exist, you have to run conan install first")
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	set(CMAKE_CXX_STANDARD 17)
 	# enable C++ x14
 	#add_definitions(-std=c++1y)
@@ -51,31 +51,28 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	set(CMAKE_CXX_STANDARD 17)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function -Wno-unused-variable")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wno-pragma-pack -Wno-missing-braces -D_CRT_SECURE_NO_WARNINGS /GS- /O2 /Ob2")
-endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+endif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+
+find_package(OpenGL REQUIRED)
+find_package(GLEW 2.1 REQUIRED)
+find_package(SDL2 2.0.9 REQUIRED)
 
 file(GLOB SOURCES "src/*.cpp" "src/*.h")
 add_executable(nes ${SOURCES})
 
-find_package(OpenGL REQUIRED)
-find_package(GLEW 2.0 REQUIRED)
-find_package(SDL2 2.0.9 REQUIRED)
+# copy non-comiling dependencies
+add_custom_command(TARGET nes POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
+		${CMAKE_SOURCE_DIR}/src/shaders
+		${CMAKE_CURRENT_BINARY_DIR}/bin/shaders)
 
-# add dependency on shaders to ensure they are included in every build/run
-#file(GLOB_RECURSE GLSL_SOURCE_FILES
-#        "src/shaders/*.frag"
-#        "src/shaders/*.vert")
+add_custom_command(TARGET nes POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
+		${CMAKE_SOURCE_DIR}/fonts
+		${CMAKE_CURRENT_BINARY_DIR}/bin/fonts)
 
-#add_custom_target(nes_shaders
-#        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/src/shaders $<TARGET_FILE_DIR:nes>/shaders
-#        DEPENDS ${GLSL_SOURCE_FILES})
-
-#add_dependencies(nes nes_shaders)
+add_custom_command(TARGET nes POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
+		${CMAKE_SOURCE_DIR}/roms
+		${CMAKE_CURRENT_BINARY_DIR}/bin/roms)
 
 # conan macro will link with all dependencies
 conan_target_link_libraries(nes)
-target_link_libraries(nes ${OPENGL_LIBRARIES} GLEW::GLEW SDL2)
-
-# copy shaders into build folder (doesn't get called when hitting cmd-r in clion with no code-changes
-#add_custom_command(TARGET nes POST_BUILD
-#        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/src/shaders $<TARGET_FILE_DIR:nes>/shaders)
-
+target_link_libraries(nes ${CONAN_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,50 +4,61 @@ project(nes)
 # include dependencies imported by conan
 if(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+	set(CONAN_SETTINGS_COMPILER "clang")
+	set(CONAN_SETTINGS_COMPILER_VERSION "8")
+	set(CONAN_SETTINGS_COMPILER_TOOLSET "clang")
     conan_basic_setup()
 else()
     message(WARNING "The file conanbuildinfo.cmake doesn't exist, you have to run conan install first")
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	set(CMAKE_CXX_STANDARD 17)
+	# enable C++ x14
+	#add_definitions(-std=c++1y)
+	#TARGET_COMPILE_OPTIONS(${BII_main_TARGET} INTERFACE "-std=c++1y")
 
-# enable C++ x14
-#add_definitions(-std=c++1y)
-#TARGET_COMPILE_OPTIONS(${BII_main_TARGET} INTERFACE "-std=c++1y")
+	# enable all warnings by default
+	#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
 
-# enable all warnings by default
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+	# suppress unwanted warnings
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function -Wno-unused-variable")
 
-# suppress unwanted warnings
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function -Wno-unused-variable")
+	# generate complete debug type info, tune for GDB (-ggdb) or LLDB (-glldb)
+	# enable address sanitization to easily catch buffer overflows and heap corruptions
+	# -O1 optimizations are compatible with address-sanitizer
+	#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O1 -fno-omit-frame-pointer -g -glldb -fsanitize=address")
 
-# generate complete debug type info, tune for GDB (-ggdb) or LLDB (-glldb)
-# enable address sanitization to easily catch buffer overflows and heap corruptions
-# -O1 optimizations are compatible with address-sanitizer
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O1 -fno-omit-frame-pointer -g -glldb -fsanitize=address")
+	# enable speed optimizations
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 
-# enable speed optimizations
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+	# generate optimization report
+	#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Rpass=inline -fsave-optimization-record")
 
-# generate optimization report
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Rpass=inline -fsave-optimization-record")
+	# improve template/type error messages
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-show-template-tree -fno-elide-type")
 
-# improve template/type error messages
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-show-template-tree -fno-elide-type")
+	# disable optimizations for profiling mode
+	#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer")
 
-# disable optimizations for profiling mode
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer")
+	#set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -rdynamic -Wl,-stack_size -Wl,0x10000")
 
-#set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -rdynamic -Wl,-stack_size -Wl,0x10000")
+	#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+	#set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-#set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+	set(CMAKE_CXX_STANDARD 17)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function -Wno-unused-variable")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wno-pragma-pack -Wno-missing-braces -D_CRT_SECURE_NO_WARNINGS /GS- /O2 /Ob2")
+endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 
 file(GLOB SOURCES "src/*.cpp" "src/*.h")
 add_executable(nes ${SOURCES})
 
 find_package(OpenGL REQUIRED)
+find_package(GLEW 2.0 REQUIRED)
+find_package(SDL2 2.0.9 REQUIRED)
 
 # add dependency on shaders to ensure they are included in every build/run
 #file(GLOB_RECURSE GLSL_SOURCE_FILES
@@ -62,7 +73,7 @@ find_package(OpenGL REQUIRED)
 
 # conan macro will link with all dependencies
 conan_target_link_libraries(nes)
-target_link_libraries(nes ${OPENGL_LIBRARIES})
+target_link_libraries(nes ${OPENGL_LIBRARIES} GLEW::GLEW SDL2)
 
 # copy shaders into build folder (doesn't get called when hitting cmd-r in clion with no code-changes
 #add_custom_command(TARGET nes POST_BUILD

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,28 @@
+﻿{
+    "configurations": [
+        {
+            "name": "x64-Debug",
+            "generator": "Ninja",
+            "configurationType": "Debug",
+            "inheritEnvironments": [ "clang_cl_x64" ],
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "-v",
+            "ctestCommandArgs": "",
+            "variables": []
+        },
+        {
+            "name": "x64-Clang-Release",
+            "generator": "Ninja",
+            "configurationType": "RelWithDebInfo",
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "-v",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "clang_cl_x64" ],
+            "variables": []
+        }
+    ]
+}

--- a/conan-resolve-win.cmd
+++ b/conan-resolve-win.cmd
@@ -1,0 +1,1 @@
+(cd out\build\x64-Debug && conan install ../../../ -s compiler.version=15)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,12 +1,13 @@
 [requires]
 sdl2/2.0.9@bincrafters/stable
-sdl2_ttf/2.0.14@bincrafters/stable
+sdl2_ttf/2.0.15@bincrafters/stable
 glm/0.9.9.1@g-truc/stable
 fftw/3.3.8@bincrafters/stable
+glew/2.1.0@bincrafters/stable
 
 [options]
 sdl2:shared=False
-sdl2_ttf:shared=False
+#sdl2_ttf:shared=False
 
 [generators]
 cmake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -7,7 +7,13 @@ glew/2.1.0@bincrafters/stable
 
 [options]
 sdl2:shared=False
+glew:shared=False
 #sdl2_ttf:shared=False
 
 [generators]
 cmake
+
+# copy all shared libs to bin build folder
+[imports]
+bin, *.dll -> ./bin
+lib, *.dylib* -> ./bin

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -6,7 +6,7 @@
 #include <fftw3.h>
 #include <algorithm>
 
-#define AUDIO_ENABLED true
+#define AUDIO_ENABLED false
 
 /**
  * References:
@@ -222,8 +222,8 @@ Audio::Audio(Raster *raster) {
     SDL_AudioSpec spec = {
             .freq = 44100,
             .format = AUDIO_U8,
-            .samples = 2048,
             .channels = 1,
+            .samples = 2048,
 
             // functor
 //            .callback = populateFuncPtr,
@@ -601,6 +601,7 @@ void Audio::execute(int cpuCycles) {
         const int writeSize = 441; // 10 msec worth of samples @ 44.1khz
 
         if (bufferWriteIdx >= writeSize) {
+			#if AUDIO_ENABLED
             int queued = SDL_GetQueuedAudioSize(1);
 
 //            PrintApu("Soundcard has %d bytes queued. sampleInterval = %d", queued, sampleInterval);
@@ -627,9 +628,10 @@ void Audio::execute(int cpuCycles) {
                     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
                     auto actual_sleep = std::chrono::duration_cast<std::chrono::milliseconds>(
                             std::chrono::high_resolution_clock::now() - now);
-//                    PrintApu("throttling apu: wanted=%d msec got=%d msec", delay, actual_sleep);
+                    PrintApu("throttling apu: wanted=%d msec got=%d msec (queued=%d samples)", delay, actual_sleep, queued);
                 }
             }
+			#endif
 
             bufferWriteIdx -= writeSize;
         }

--- a/src/Backtrace.cpp
+++ b/src/Backtrace.cpp
@@ -1,3 +1,4 @@
+#ifndef _WIN32
 #include "Backtrace.h"
 
 #include <regex>
@@ -131,3 +132,4 @@ Backtrace::demangle(const char* mangled, char *unmangled, size_t bufferSize) {
         snprintf(unmangled, bufferSize, "%3s [%s] %s", frameNumber, library, method);
     }
 }
+#endif

--- a/src/Backtrace.h
+++ b/src/Backtrace.h
@@ -1,3 +1,4 @@
+#ifndef _WIN32
 #pragma once
 
 #include <cstring>
@@ -10,3 +11,4 @@ public:
     static void demangle(const char* mangled, char* unmangled, size_t bufferSize);
     static void* getCallerAddress(ucontext_t *uc);
 };
+#endif

--- a/src/Cartridge.h
+++ b/src/Cartridge.h
@@ -5,7 +5,8 @@
 const unsigned int PRG_ROM_PAGE_SIZE = 0x4000;
 const unsigned int CHR_ROM_PAGE_SIZE = 0x2000;
 
-struct __attribute__((packed)) RomHeader {
+#pragma pack(push, 1)
+struct RomHeader {
     uint8_t signature[4];
     uint8_t numPrgPages;
     uint8_t numChrPages;
@@ -14,6 +15,7 @@ struct __attribute__((packed)) RomHeader {
 
     uint8_t reserved[8];
 };
+#pragma pack(pop)
 
 enum eMirroringType {
     VERTICAL_MIRRORING, HORIZONTAL_MIRRORING

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -227,7 +227,7 @@ GUI::GUI(Raster* raster)
         exit(1);
     }
 
-    font = TTF_OpenFont("../../../../fonts/visitor2.ttf", 19);
+    font = TTF_OpenFont("fonts/visitor2.ttf", 19);
     if (font == nullptr) {
         PrintError("Failed to open font: %s", TTF_GetError());
         exit(1);
@@ -470,20 +470,20 @@ GLuint loadShader(GLenum type, const char *shaderName, const char *shaderFilePat
 void checkShaderCompilationError(const char *shaderName, GLuint shaderId);
 
 void GUI::createShaders() {
-    GLuint passthruVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../../../src/shaders/passthru.vert");
-    GLuint passthroughFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../../../src/shaders/passthru.frag");
+    GLuint passthruVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "shaders/passthru.vert");
+    GLuint passthroughFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "shaders/passthru.frag");
     passThruShader = createProgram(passthruVertex, passthroughFragment);
 
-    GLuint gBufferVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../../../src/shaders/create-gbuffer.vert");
-    GLuint gBufferFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../../../src/shaders/create-gbuffer.frag");
+    GLuint gBufferVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "shaders/create-gbuffer.vert");
+    GLuint gBufferFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "shaders/create-gbuffer.frag");
     createGBufferShader = createProgram(gBufferVertex, gBufferFragment);
 
-    GLuint blurVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../../../src/shaders/blur.vert");
-    GLuint blurFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../../../src/shaders/blur.frag");
+    GLuint blurVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "shaders/blur.vert");
+    GLuint blurFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "shaders/blur.frag");
     blurShader = createProgram(blurVertex, blurFragment);
 
-    GLuint composeVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../../../src/shaders/compose.vert");
-    GLuint composeFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../../../src/shaders/compose.frag");
+    GLuint composeVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "shaders/compose.vert");
+    GLuint composeFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "shaders/compose.frag");
     composeShader = createProgram(composeVertex, composeFragment);
 
     GLint numAttributes;

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -41,35 +41,35 @@ GLenum glCheckError_(const char *file, int line) {
 
 #define glCheckError() glCheckError_(__FILE__, __LINE__)
 
-GUI::GUI(Raster* raster)
-	: raster(raster) {
+GUI::GUI(Raster *raster)
+        : raster(raster) {
 
-	showEnhancedPPU = false;
-	showDebuggerPPU = true;
-	showDebuggerAPU = true;
+    showEnhancedPPU = false;
+    showDebuggerPPU = true;
+    showDebuggerAPU = true;
 
-	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
-		PrintError("SDL_Init failed: %s", SDL_GetError());
-		throw std::runtime_error("SDL_Init failed");
-	}
+    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+        PrintError("SDL_Init failed: %s", SDL_GetError());
+        throw std::runtime_error("SDL_Init failed");
+    }
 
     if (showDebuggerAPU) {
         // Create software-rendering Window
         apuDebugWindow = SDL_CreateWindow("APU Debugger", 0, 0, 520, 828, SDL_WINDOW_ALLOW_HIGHDPI);
-	    if (apuDebugWindow == nullptr) {
+        if (apuDebugWindow == nullptr) {
             PrintError("SDL_CreateWindow#1 failed: %s", SDL_GetError());
             throw std::runtime_error("SDL_CreateWindow#1 failed");
         }
 
         // This will create an OpenGL 2.1 context behind the scenes.
         apuDebugRenderer = SDL_CreateRenderer(apuDebugWindow, -1, SDL_RENDERER_PRESENTVSYNC);
-	    if (apuDebugRenderer == nullptr) {
+        if (apuDebugRenderer == nullptr) {
             PrintError("SDL_CreateRenderer failed: %s", SDL_GetError());
             throw std::runtime_error("SDL_CreateRenderer failed");
         }
 
         SDL_RaiseWindow(apuDebugWindow);
-	
+
         // set logical size equal to window size
         // this allows for unscaled/nearest-neighbor pixel-accurate output
         // on hi-dpi screens where renderer output size != window size
@@ -88,78 +88,78 @@ GUI::GUI(Raster* raster)
         noiseWaveformTexture = SDL_CreateTexture(apuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 1024, 64);
     }
 
-	if (showDebuggerPPU) {
-		// Create software-rendering Window
-		ppuDebugWindow = SDL_CreateWindow("NES - Debug", 0, 330, 1320, 564, SDL_WINDOW_ALLOW_HIGHDPI);
-		if (ppuDebugWindow == nullptr) {
-			PrintError("SDL_CreateWindow#1 failed: %s", SDL_GetError());
-			throw std::runtime_error("SDL_CreateWindow#1 failed");
-		}
+    if (showDebuggerPPU) {
+        // Create software-rendering Window
+        ppuDebugWindow = SDL_CreateWindow("NES - Debug", 0, 330, 1320, 564, SDL_WINDOW_ALLOW_HIGHDPI);
+        if (ppuDebugWindow == nullptr) {
+            PrintError("SDL_CreateWindow#1 failed: %s", SDL_GetError());
+            throw std::runtime_error("SDL_CreateWindow#1 failed");
+        }
 
-		// This will create an OpenGL 2.1 context behind the scenes.
-		ppuDebugRenderer = SDL_CreateRenderer(ppuDebugWindow, -1, SDL_RENDERER_PRESENTVSYNC);
-		if (ppuDebugRenderer == nullptr) {
-			PrintError("SDL_CreateRenderer failed: %s", SDL_GetError());
-			throw std::runtime_error("SDL_CreateRenderer failed");
-		}
+        // This will create an OpenGL 2.1 context behind the scenes.
+        ppuDebugRenderer = SDL_CreateRenderer(ppuDebugWindow, -1, SDL_RENDERER_PRESENTVSYNC);
+        if (ppuDebugRenderer == nullptr) {
+            PrintError("SDL_CreateRenderer failed: %s", SDL_GetError());
+            throw std::runtime_error("SDL_CreateRenderer failed");
+        }
 
-		SDL_RendererInfo info;
-		SDL_GetRendererInfo(ppuDebugRenderer, &info);
-		PrintInfo("info.num_texture_formats = %d", info.num_texture_formats);
-		for (int i = 0; i < info.num_texture_formats; i++) {
-			PrintInfo("  %s = %d bytes/pixel", SDL_GetPixelFormatName(info.texture_formats[i]),
-				SDL_BYTESPERPIXEL(info.texture_formats[i]));
-		}
+        SDL_RendererInfo info;
+        SDL_GetRendererInfo(ppuDebugRenderer, &info);
+        PrintInfo("info.num_texture_formats = %d", info.num_texture_formats);
+        for (int i = 0; i < info.num_texture_formats; i++) {
+            PrintInfo("  %s = %d bytes/pixel", SDL_GetPixelFormatName(info.texture_formats[i]),
+                      SDL_BYTESPERPIXEL(info.texture_formats[i]));
+        }
 
-		finalTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 256);
-		patternTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 128, 256);
-		attributeTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 256);
-		paletteTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 32);
-		nametableTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 512, 512);
-		backgroundMaskTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_NV12, SDL_TEXTUREACCESS_STREAMING, 256, 256);
-		spriteMaskTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_NV12, SDL_TEXTUREACCESS_STREAMING, 256, 256);
+        finalTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 256);
+        patternTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 128, 256);
+        attributeTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 256);
+        paletteTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 32);
+        nametableTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 512, 512);
+        backgroundMaskTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_NV12, SDL_TEXTUREACCESS_STREAMING, 256, 256);
+        spriteMaskTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_NV12, SDL_TEXTUREACCESS_STREAMING, 256, 256);
 
-		if (finalTexture == nullptr) {
-			PrintError("SDL_CreateTexture failed: %s", SDL_GetError());
-			throw std::runtime_error("SDL_CreateTexture failed");
-		}
+        if (finalTexture == nullptr) {
+            PrintError("SDL_CreateTexture failed: %s", SDL_GetError());
+            throw std::runtime_error("SDL_CreateTexture failed");
+        }
 
-		if (backgroundMaskTexture == nullptr) {
-			PrintError("SDL_CreateTexture failed: %s", SDL_GetError());
-			throw std::runtime_error("SDL_CreateTexture failed");
-		}
+        if (backgroundMaskTexture == nullptr) {
+            PrintError("SDL_CreateTexture failed: %s", SDL_GetError());
+            throw std::runtime_error("SDL_CreateTexture failed");
+        }
 
-		SDL_RaiseWindow(ppuDebugWindow);
+        SDL_RaiseWindow(ppuDebugWindow);
 
-		int w, h;
+        int w, h;
 
-		// set logical size equal to window size
-		// this allows for unscaled/nearest-neighbor pixel-accurate output
-		// on hi-dpi screens where renderer output size != window size
-		SDL_GetWindowSize(ppuDebugWindow, &w, &h);
-		PrintInfo("Debug Window size: %d x %d", w, h);
-		SDL_RenderSetLogicalSize(ppuDebugRenderer, w, h);
+        // set logical size equal to window size
+        // this allows for unscaled/nearest-neighbor pixel-accurate output
+        // on hi-dpi screens where renderer output size != window size
+        SDL_GetWindowSize(ppuDebugWindow, &w, &h);
+        PrintInfo("Debug Window size: %d x %d", w, h);
+        SDL_RenderSetLogicalSize(ppuDebugRenderer, w, h);
 
-		//    SDL_GetWindowSize(glWindow, &w, &h);
-		//    PrintInfo("OpenGL Window size: %d x %d", w, h);
+        //    SDL_GetWindowSize(glWindow, &w, &h);
+        //    PrintInfo("OpenGL Window size: %d x %d", w, h);
 
-		SDL_GL_GetDrawableSize(ppuDebugWindow, &w, &h);
-		PrintInfo("Debug Window drawable size: %d x %d", w, h);
+        SDL_GL_GetDrawableSize(ppuDebugWindow, &w, &h);
+        PrintInfo("Debug Window drawable size: %d x %d", w, h);
 
-		//    SDL_GL_GetDrawableSize(glWindow, &w, &h);
-		//    PrintInfo("OpenGL Window drawable size: %d x %d", w, h);
-		//    glCheckError();
+        //    SDL_GL_GetDrawableSize(glWindow, &w, &h);
+        //    PrintInfo("OpenGL Window drawable size: %d x %d", w, h);
+        //    glCheckError();
 
-		SDL_GetRendererOutputSize(ppuDebugRenderer, &w, &h);
-		PrintInfo("Debug Window Renderer output size: %d x %d", w, h);
+        SDL_GetRendererOutputSize(ppuDebugRenderer, &w, &h);
+        PrintInfo("Debug Window Renderer output size: %d x %d", w, h);
 
-		SDL_Rect rect;
-		SDL_RenderGetViewport(ppuDebugRenderer, &rect);
-		PrintInfo("Debug Window Renderer viewport: %d x %d @ %d, %d", rect.w, rect.h, rect.x, rect.y);
+        SDL_Rect rect;
+        SDL_RenderGetViewport(ppuDebugRenderer, &rect);
+        PrintInfo("Debug Window Renderer viewport: %d x %d @ %d, %d", rect.w, rect.h, rect.x, rect.y);
 
-		SDL_RenderGetLogicalSize(ppuDebugRenderer, &w, &h);
-		PrintInfo("Debug Window Renderer logical size: %d x %d", w, h);
-	}
+        SDL_RenderGetLogicalSize(ppuDebugRenderer, &w, &h);
+        PrintInfo("Debug Window Renderer logical size: %d x %d", w, h);
+    }
 
     if (showEnhancedPPU) {
         // Reconfigure preferred OpenGL settings: Profile = Core and Version = 3.1
@@ -190,12 +190,12 @@ GUI::GUI(Raster* raster)
             PrintError("SDL_GL_CreateContext failed: %s", SDL_GetError());
         }
 
-		// initialize OpenGL driver
-		GLenum glewErr = glewInit();
-		if (glewErr != GLEW_OK) {
-			std::cout << "glew error: " << glewGetErrorString(glewErr) << std::endl;
-		}
-		
+        // initialize OpenGL driver
+        GLenum glewErr = glewInit();
+        if (glewErr != GLEW_OK) {
+            std::cout << "glew error: " << glewGetErrorString(glewErr) << std::endl;
+        }
+
         // Dump OpenGL versioning info
 
         PrintInfo("OpenGL Vendor: %s", glGetString(GL_VENDOR));

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -5,6 +5,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/transform.hpp>
+#include <chrono>
 
 //#include <SDL2/SDL_opengl.h>
 #include "GUI.h"
@@ -12,7 +13,7 @@
 
 GLenum glCheckError_(const char *file, int line) {
     GLenum errorCode;
-    while ((errorCode = glGetError()) != GL_NO_ERROR) {
+    if ((errorCode = glGetError()) != GL_NO_ERROR) {
         std::string error;
         switch (errorCode) {
             case GL_INVALID_ENUM:
@@ -40,35 +41,35 @@ GLenum glCheckError_(const char *file, int line) {
 
 #define glCheckError() glCheckError_(__FILE__, __LINE__)
 
-GUI::GUI(Raster *raster)
-        : raster(raster) {
+GUI::GUI(Raster* raster)
+	: raster(raster) {
 
-    showEnhancedPPU = false;
-    showDebuggerPPU = true;
-    showDebuggerAPU = true;
+	showEnhancedPPU = false;
+	showDebuggerPPU = true;
+	showDebuggerAPU = true;
 
-    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
-        PrintError("SDL_Init failed: %s", SDL_GetError());
-        throw std::runtime_error("SDL_Init failed");
-    }
+	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+		PrintError("SDL_Init failed: %s", SDL_GetError());
+		throw std::runtime_error("SDL_Init failed");
+	}
 
     if (showDebuggerAPU) {
         // Create software-rendering Window
         apuDebugWindow = SDL_CreateWindow("APU Debugger", 0, 0, 520, 828, SDL_WINDOW_ALLOW_HIGHDPI);
-        if (apuDebugWindow == nullptr) {
+	    if (apuDebugWindow == nullptr) {
             PrintError("SDL_CreateWindow#1 failed: %s", SDL_GetError());
             throw std::runtime_error("SDL_CreateWindow#1 failed");
         }
 
         // This will create an OpenGL 2.1 context behind the scenes.
         apuDebugRenderer = SDL_CreateRenderer(apuDebugWindow, -1, SDL_RENDERER_PRESENTVSYNC);
-        if (apuDebugRenderer == nullptr) {
+	    if (apuDebugRenderer == nullptr) {
             PrintError("SDL_CreateRenderer failed: %s", SDL_GetError());
             throw std::runtime_error("SDL_CreateRenderer failed");
         }
 
         SDL_RaiseWindow(apuDebugWindow);
-
+	
         // set logical size equal to window size
         // this allows for unscaled/nearest-neighbor pixel-accurate output
         // on hi-dpi screens where renderer output size != window size
@@ -76,7 +77,6 @@ GUI::GUI(Raster *raster)
         SDL_GetWindowSize(apuDebugWindow, &w, &h);
         PrintInfo("APU Debug Window size: %d x %d", w, h);
         SDL_RenderSetLogicalSize(apuDebugRenderer, w, h);
-        glCheckError();
 
         square1FFTTexture = SDL_CreateTexture(apuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 512, 64);
         square1WaveformTexture = SDL_CreateTexture(apuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 1024, 64);
@@ -88,83 +88,78 @@ GUI::GUI(Raster *raster)
         noiseWaveformTexture = SDL_CreateTexture(apuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 1024, 64);
     }
 
-    if (showDebuggerPPU) {
-        // Create software-rendering Window
-        ppuDebugWindow = SDL_CreateWindow("NES - Debug", 0, 330, 1320, 564, SDL_WINDOW_ALLOW_HIGHDPI);
-        if (ppuDebugWindow == nullptr) {
-            PrintError("SDL_CreateWindow#1 failed: %s", SDL_GetError());
-            throw std::runtime_error("SDL_CreateWindow#1 failed");
-        }
+	if (showDebuggerPPU) {
+		// Create software-rendering Window
+		ppuDebugWindow = SDL_CreateWindow("NES - Debug", 0, 330, 1320, 564, SDL_WINDOW_ALLOW_HIGHDPI);
+		if (ppuDebugWindow == nullptr) {
+			PrintError("SDL_CreateWindow#1 failed: %s", SDL_GetError());
+			throw std::runtime_error("SDL_CreateWindow#1 failed");
+		}
 
-        // This will create an OpenGL 2.1 context behind the scenes.
-        ppuDebugRenderer = SDL_CreateRenderer(ppuDebugWindow, -1, SDL_RENDERER_PRESENTVSYNC);
-        if (ppuDebugRenderer == nullptr) {
-            PrintError("SDL_CreateRenderer failed: %s", SDL_GetError());
-            throw std::runtime_error("SDL_CreateRenderer failed");
-        }
+		// This will create an OpenGL 2.1 context behind the scenes.
+		ppuDebugRenderer = SDL_CreateRenderer(ppuDebugWindow, -1, SDL_RENDERER_PRESENTVSYNC);
+		if (ppuDebugRenderer == nullptr) {
+			PrintError("SDL_CreateRenderer failed: %s", SDL_GetError());
+			throw std::runtime_error("SDL_CreateRenderer failed");
+		}
 
-        SDL_RendererInfo info;
-        SDL_GetRendererInfo(ppuDebugRenderer, &info);
-        PrintInfo("info.num_texture_formats = %d", info.num_texture_formats);
-        for (int i = 0; i < info.num_texture_formats; i++) {
-            PrintInfo("  %s = %d bytes/pixel", SDL_GetPixelFormatName(info.texture_formats[i]),
-                      SDL_BYTESPERPIXEL(info.texture_formats[i]));
-        }
+		SDL_RendererInfo info;
+		SDL_GetRendererInfo(ppuDebugRenderer, &info);
+		PrintInfo("info.num_texture_formats = %d", info.num_texture_formats);
+		for (int i = 0; i < info.num_texture_formats; i++) {
+			PrintInfo("  %s = %d bytes/pixel", SDL_GetPixelFormatName(info.texture_formats[i]),
+				SDL_BYTESPERPIXEL(info.texture_formats[i]));
+		}
 
-        finalTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 256);
-        patternTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 128, 256);
-        attributeTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 256);
-        paletteTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 32);
-        nametableTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 512, 512);
-        backgroundMaskTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_NV12, SDL_TEXTUREACCESS_STREAMING, 256, 256);
-        spriteMaskTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_NV12, SDL_TEXTUREACCESS_STREAMING, 256, 256);
+		finalTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 256);
+		patternTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 128, 256);
+		attributeTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 256);
+		paletteTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 32);
+		nametableTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 512, 512);
+		backgroundMaskTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_NV12, SDL_TEXTUREACCESS_STREAMING, 256, 256);
+		spriteMaskTexture = SDL_CreateTexture(ppuDebugRenderer, SDL_PIXELFORMAT_NV12, SDL_TEXTUREACCESS_STREAMING, 256, 256);
 
-        if (finalTexture == nullptr) {
-            PrintError("SDL_CreateTexture failed: %s", SDL_GetError());
-            throw std::runtime_error("SDL_CreateTexture failed");
-        }
+		if (finalTexture == nullptr) {
+			PrintError("SDL_CreateTexture failed: %s", SDL_GetError());
+			throw std::runtime_error("SDL_CreateTexture failed");
+		}
 
-        if (backgroundMaskTexture == nullptr) {
-            PrintError("SDL_CreateTexture failed: %s", SDL_GetError());
-            throw std::runtime_error("SDL_CreateTexture failed");
-        }
+		if (backgroundMaskTexture == nullptr) {
+			PrintError("SDL_CreateTexture failed: %s", SDL_GetError());
+			throw std::runtime_error("SDL_CreateTexture failed");
+		}
 
-        SDL_RaiseWindow(ppuDebugWindow);
+		SDL_RaiseWindow(ppuDebugWindow);
 
-        int w, h;
+		int w, h;
 
-        // set logical size equal to window size
-        // this allows for unscaled/nearest-neighbor pixel-accurate output
-        // on hi-dpi screens where renderer output size != window size
-        SDL_GetWindowSize(ppuDebugWindow, &w, &h);
-        PrintInfo("Debug Window size: %d x %d", w, h);
-        SDL_RenderSetLogicalSize(ppuDebugRenderer, w, h);
-        glCheckError();
+		// set logical size equal to window size
+		// this allows for unscaled/nearest-neighbor pixel-accurate output
+		// on hi-dpi screens where renderer output size != window size
+		SDL_GetWindowSize(ppuDebugWindow, &w, &h);
+		PrintInfo("Debug Window size: %d x %d", w, h);
+		SDL_RenderSetLogicalSize(ppuDebugRenderer, w, h);
 
-//    SDL_GetWindowSize(glWindow, &w, &h);
-//    PrintInfo("OpenGL Window size: %d x %d", w, h);
+		//    SDL_GetWindowSize(glWindow, &w, &h);
+		//    PrintInfo("OpenGL Window size: %d x %d", w, h);
 
-        SDL_GL_GetDrawableSize(ppuDebugWindow, &w, &h);
-        PrintInfo("Debug Window drawable size: %d x %d", w, h);
-        glCheckError();
+		SDL_GL_GetDrawableSize(ppuDebugWindow, &w, &h);
+		PrintInfo("Debug Window drawable size: %d x %d", w, h);
 
-//    SDL_GL_GetDrawableSize(glWindow, &w, &h);
-//    PrintInfo("OpenGL Window drawable size: %d x %d", w, h);
-//    glCheckError();
+		//    SDL_GL_GetDrawableSize(glWindow, &w, &h);
+		//    PrintInfo("OpenGL Window drawable size: %d x %d", w, h);
+		//    glCheckError();
 
-        SDL_GetRendererOutputSize(ppuDebugRenderer, &w, &h);
-        PrintInfo("Debug Window Renderer output size: %d x %d", w, h);
-        glCheckError();
+		SDL_GetRendererOutputSize(ppuDebugRenderer, &w, &h);
+		PrintInfo("Debug Window Renderer output size: %d x %d", w, h);
 
-        SDL_Rect rect;
-        SDL_RenderGetViewport(ppuDebugRenderer, &rect);
-        PrintInfo("Debug Window Renderer viewport: %d x %d @ %d, %d", rect.w, rect.h, rect.x, rect.y);
-        glCheckError();
+		SDL_Rect rect;
+		SDL_RenderGetViewport(ppuDebugRenderer, &rect);
+		PrintInfo("Debug Window Renderer viewport: %d x %d @ %d, %d", rect.w, rect.h, rect.x, rect.y);
 
-        SDL_RenderGetLogicalSize(ppuDebugRenderer, &w, &h);
-        PrintInfo("Debug Window Renderer logical size: %d x %d", w, h);
-        glCheckError();
-    }
+		SDL_RenderGetLogicalSize(ppuDebugRenderer, &w, &h);
+		PrintInfo("Debug Window Renderer logical size: %d x %d", w, h);
+	}
 
     if (showEnhancedPPU) {
         // Reconfigure preferred OpenGL settings: Profile = Core and Version = 3.1
@@ -195,6 +190,12 @@ GUI::GUI(Raster *raster)
             PrintError("SDL_GL_CreateContext failed: %s", SDL_GetError());
         }
 
+		// initialize OpenGL driver
+		GLenum glewErr = glewInit();
+		if (glewErr != GLEW_OK) {
+			std::cout << "glew error: " << glewGetErrorString(glewErr) << std::endl;
+		}
+		
         // Dump OpenGL versioning info
 
         PrintInfo("OpenGL Vendor: %s", glGetString(GL_VENDOR));
@@ -210,9 +211,9 @@ GUI::GUI(Raster *raster)
 
 //    SDL_WM_SetCaption( "TTF Test", NULL );
 
-        SDL_GL_SetSwapInterval(1);
-        int swapInterval = SDL_GL_GetSwapInterval();
-        PrintInfo("VSync interval: %d", swapInterval);
+        //SDL_GL_SetSwapInterval(1);
+        //int swapInterval = SDL_GL_GetSwapInterval();
+        //PrintInfo("VSync interval: %d", swapInterval);
 
         SDL_RaiseWindow(glWindow);
 
@@ -226,7 +227,7 @@ GUI::GUI(Raster *raster)
         exit(1);
     }
 
-    font = TTF_OpenFont("../../fonts/visitor2.ttf", 19);
+    font = TTF_OpenFont("../../../../fonts/visitor2.ttf", 19);
     if (font == nullptr) {
         PrintError("Failed to open font: %s", TTF_GetError());
         exit(1);
@@ -256,7 +257,7 @@ GUI::render() {
         // render into debug window
         renderDebugViews();
         auto span = std::chrono::high_resolution_clock::now() - now;
-        PrintInfo("Rendering PPU Debugger took %d msec", std::chrono::duration_cast<std::chrono::milliseconds>(span));
+        //PrintInfo("Rendering PPU Debugger took %d msec", std::chrono::duration_cast<std::chrono::milliseconds>(span));
     }
 
     if (showEnhancedPPU) {
@@ -469,20 +470,20 @@ GLuint loadShader(GLenum type, const char *shaderName, const char *shaderFilePat
 void checkShaderCompilationError(const char *shaderName, GLuint shaderId);
 
 void GUI::createShaders() {
-    GLuint passthruVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../src/shaders/passthru.vert");
-    GLuint passthroughFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../src/shaders/passthru.frag");
+    GLuint passthruVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../../../src/shaders/passthru.vert");
+    GLuint passthroughFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../../../src/shaders/passthru.frag");
     passThruShader = createProgram(passthruVertex, passthroughFragment);
 
-    GLuint gBufferVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../src/shaders/create-gbuffer.vert");
-    GLuint gBufferFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../src/shaders/create-gbuffer.frag");
+    GLuint gBufferVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../../../src/shaders/create-gbuffer.vert");
+    GLuint gBufferFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../../../src/shaders/create-gbuffer.frag");
     createGBufferShader = createProgram(gBufferVertex, gBufferFragment);
 
-    GLuint blurVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../src/shaders/blur.vert");
-    GLuint blurFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../src/shaders/blur.frag");
+    GLuint blurVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../../../src/shaders/blur.vert");
+    GLuint blurFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../../../src/shaders/blur.frag");
     blurShader = createProgram(blurVertex, blurFragment);
 
-    GLuint composeVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../src/shaders/compose.vert");
-    GLuint composeFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../src/shaders/compose.frag");
+    GLuint composeVertex = loadShader(GL_VERTEX_SHADER, "vertex shader", "../../../../src/shaders/compose.vert");
+    GLuint composeFragment = loadShader(GL_FRAGMENT_SHADER, "fragment shader", "../../../../src/shaders/compose.frag");
     composeShader = createProgram(composeVertex, composeFragment);
 
     GLint numAttributes;

--- a/src/GUI.h
+++ b/src/GUI.h
@@ -2,8 +2,7 @@
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
-#include <OpenGL/gl3.h>
-#include <OpenGL/gl3ext.h>
+#include <GL/glew.h>
 #include "Platform.h"
 #include "PPU.h"
 #include <map>

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -29,6 +29,7 @@ Loggy::simplifyFunctionName(const char *name, char *shorter, size_t maxLength) {
     snprintf(shorter, maxLength, "%s%.*s%s(); ", prefix, int(end - start), start, postfix);
 }
 
+
 void
 Loggy::println(const char *fmt, ...) {
     if (Enabled > type) {

--- a/src/Logging.h
+++ b/src/Logging.h
@@ -1,6 +1,11 @@
 #pragma once
 
 #include <iostream>
+#ifdef _WIN32
+	#include <cassert> // assert()
+	#include <stdarg.h> // va_start()
+	#define __PRETTY_FUNCTION__ __FUNCSIG__
+#endif
 
 struct Loggy {
     enum Type {

--- a/src/MemoryIO.cpp
+++ b/src/MemoryIO.cpp
@@ -272,7 +272,7 @@ MemoryIO::MemoryIO(PPU *ppu, Joypad *joypad, Audio *apu)
 
 class MemoryIOPortException : public ExceptionBase<MemoryIOPortException> {
 public:
-    MemoryIOPortException(const char* str)
+    MemoryIOPortException(const char *str)
             : ExceptionBase(str) {}
 };
 
@@ -330,7 +330,7 @@ MemoryIO::write(tCPU::word address, tCPU::byte value) {
             MemoryIOHandler<0x4003>::write(apu, value);
             break;
 
-        // Audio - square waveform channel 2
+            // Audio - square waveform channel 2
         case 0x4004:
             MemoryIOHandler<0x4004>::write(apu, value);
             break;
@@ -377,8 +377,8 @@ MemoryIO::write(tCPU::word address, tCPU::byte value) {
             break;
 
         case 0x4010:
-		case 0x4012:
-		case 0x4013:
+        case 0x4012:
+        case 0x4013:
 //            PrintUnimplementedIO("Skipping Unimplemented I/O Port: APU $%04X - APU", address);
             break;
 

--- a/src/MemoryIO.cpp
+++ b/src/MemoryIO.cpp
@@ -376,8 +376,9 @@ MemoryIO::write(tCPU::word address, tCPU::byte value) {
             MemoryIOHandler<0x400F>::write(apu, value);
             break;
 
-        case 0x4010 ... 0x4010:
-        case 0x4012 ... 0x4013:
+        case 0x4010:
+		case 0x4012:
+		case 0x4013:
 //            PrintUnimplementedIO("Skipping Unimplemented I/O Port: APU $%04X - APU", address);
             break;
 

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -303,24 +303,24 @@ void PPU::onEnterHBlank() {
 
 void PPU::renderScanline(const tCPU::word Y) {
     // tiles are 8x8 pixel in size.
-    ushort tileSizePixels = 8;
+    unsigned short int tileSizePixels = 8;
     // row number within tile
-    ushort tileRow = ushort(Y % tileSizePixels);
+    unsigned short int tileRow = Y % tileSizePixels;
     // tile horizontal position within frame
-    ushort tileY = ushort(floor(Y / tileSizePixels));
+    unsigned short int tileY = floor(Y / tileSizePixels);
 
     // attributes are 32x32 pixels in size
-    ushort attributeY = ushort(tileY / 4);
+    unsigned short int attributeY = tileY / 4;
 
     // decode scanline
     // 256 pixels in 32 bytes, each byte a tile consisting of 8 pixels
 
     tCPU::word nametableAddy = settings.NameTableAddress;
 
-    ushort tileScroll = ushort(vramAddress14bit & 0xFF);
-    ushort attributeScroll = ushort(vramAddress14bit & 0x0C00)
-                             | ushort((vramAddress14bit >> 4) & 0x38)
-                             | ushort((vramAddress14bit >> 2) & 0x07);
+    unsigned short int tileScroll = vramAddress14bit & 0xFF;
+    unsigned short int attributeScroll = (vramAddress14bit & 0x0C00)
+                             | ((vramAddress14bit >> 4) & 0x38)
+                             | ((vramAddress14bit >> 2) & 0x07);
 
 //    tileScroll = 0;
     attributeScroll = 0; // ignoring attribute scroll from vram, using tile instead
@@ -334,11 +334,11 @@ void PPU::renderScanline(const tCPU::word Y) {
      * 32 tiles per scanline
      */
 
-    ushort numTiles = 32; // 32 tiles per scanline
-    ushort numAttributes = 8; // 8 attributes per scanline (4 per tile)
+    unsigned short int numTiles = 32; // 32 tiles per scanline
+    unsigned short int numAttributes = 8; // 8 attributes per scanline (4 per tile)
 
     if (settings.BackgroundVisible)
-        for (ushort i = 0; i <= numTiles; i++) {
+        for (unsigned short int i = 0; i <= numTiles; i++) {
             auto nametable = nametableAddy;
             auto nametableAttributeOffset = nametableAddy + 0x3C0;
 
@@ -353,8 +353,8 @@ void PPU::renderScanline(const tCPU::word Y) {
             // each attribute block is 32x32 pixels
             // there are 8 attribute blocks per scanline
             // each attribute block covers 4 tiles
-            ushort attributeBase = nametableAttributeOffset + attributeScroll;
-            ushort attributeX = (((i + tileScroll) % 32) >> 2); // new attribute block every 4 tiles
+            unsigned short int attributeBase = nametableAttributeOffset + attributeScroll;
+            unsigned short int attributeX = (((i + tileScroll) % 32) >> 2); // new attribute block every 4 tiles
             auto attribute = ReadByteFromPPU(attributeBase + attributeY * numAttributes + attributeX);
 //        auto preScaledUpperBits = (attribute >> ((i & 2) | ((tileY & 2) << 1))) & 3;
 //        preScaledUpperBits *= 4;
@@ -382,9 +382,9 @@ void PPU::renderScanline(const tCPU::word Y) {
             // render single row within the 8x8 pixel tile
             // each pattern block is 16 bytes long: two sections of 8 bytes each
             // each byte corresponds to 8 pixels. total: 2 bits per pixel
-            ushort patternBytes = 16;
-            ushort patternSize = 8;
-            ushort patternOffset = settings.BackgroundPatternTableAddress + tileIdx * patternBytes;
+            unsigned short int patternBytes = 16;
+            unsigned short int patternSize = 8;
+            unsigned short int patternOffset = settings.BackgroundPatternTableAddress + tileIdx * patternBytes;
             auto patternByte0 = ReadByteFromPPU(patternOffset + tileRow);
             auto patternByte1 = ReadByteFromPPU(patternOffset + tileRow + patternSize);
 
@@ -885,6 +885,14 @@ PPU::StartSpriteXferDMA(Memory *memory, tCPU::byte address) {
 //    vramAddress14bit = 0;
 }
 
+#ifdef _WIN32
+void memset_pattern4(void* p_destination, const void* p_pattern, size_t p_count) {
+	for (size_t i = 0; i < (p_count / 4); i++) {
+		memcpy((( char*) p_destination) + (i * 4), p_pattern, 4);
+	}
+}
+#endif
+
 void PPU::clear() {
     // clear final output (256x256@32bit)
     uint32_t clearPattern = 0xff333333;
@@ -1363,10 +1371,10 @@ void PPU::RenderDebugNametables() {
     }
 
     // render viewport scrolling
-    ushort tileScroll = ushort(vramAddress14bit & 0x0FFF);
-    ushort tileScrollPixels = tileScroll * 8;
-    ushort nametableOffsetX = ((settings.NameTableAddress - 0x2000) / 0x400) * 256;
-    ushort horizontalScrollPixels = nametableOffsetX + horizontalScrollOrigin + tileScrollPixels;
+    unsigned short int tileScroll = vramAddress14bit & 0x0FFF;
+    unsigned short int tileScrollPixels = tileScroll * 8;
+    unsigned short int nametableOffsetX = ((settings.NameTableAddress - 0x2000) / 0x400) * 256;
+    unsigned short int horizontalScrollPixels = nametableOffsetX + horizontalScrollOrigin + tileScrollPixels;
 
     // rows
     for (auto i = 0; i < 256; i++) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,7 +190,7 @@ Cartridge loadCartridge() {
 
     /////////////////////////////////////////////////
 // mapper=0 aka NROM
-    Cartridge rom = loader.loadCartridge("../../../../roms/supermariobros.nes"); // played through at least one level
+    Cartridge rom = loader.loadCartridge("roms/supermariobros.nes"); // played through at least one level
 //    Cartridge rom = loader.loadCartridge("../roms/donkey_kong.nes"); // draws zeroes instead of sprites
 //    rom.info.memoryMapperId = 0;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,8 +15,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <cstdlib>
-#include <unistd.h>
+//#include <unistd.h>
 #include <thread>
+#include <chrono>
 
 using namespace std::chrono_literals;
 typedef std::chrono::high_resolution_clock clock_type;
@@ -28,7 +29,7 @@ void printLibVersions();
 Cartridge loadCartridge();
 
 int main(int argc, char **argv) {
-    Backtrace::install();
+    //Backtrace::install();
     printLibVersions();
 
     Cartridge rom = loadCartridge();
@@ -144,17 +145,15 @@ int main(int argc, char **argv) {
             auto span = now - last;
             last = now;
 
-            /*
             // throttle to around 60fps
             const std::chrono::milliseconds &goal = 16ms;
-            auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(span - goal);
-            if(gap > 2ms) {
+            auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(goal - span);
+            if(gap > 0ms) {
                 now = std::chrono::high_resolution_clock::now();
                 std::this_thread::sleep_for(gap);
                 auto actual_delay = std::chrono::high_resolution_clock::now() - now;
                 PrintInfo("throttling ppu: wanted=%d msec got=%d msec", gap, std::chrono::duration_cast<std::chrono::milliseconds>(actual_delay));
             }
-            */
         }
     }
 
@@ -168,6 +167,7 @@ int main(int argc, char **argv) {
     delete gui;
 
     audio->close();
+	return 0;
 }
 
 Cartridge loadCartridge() {
@@ -190,7 +190,7 @@ Cartridge loadCartridge() {
 
     /////////////////////////////////////////////////
 // mapper=0 aka NROM
-    Cartridge rom = loader.loadCartridge("../../roms/supermariobros.nes"); // played through at least one level
+    Cartridge rom = loader.loadCartridge("../../../../roms/supermariobros.nes"); // played through at least one level
 //    Cartridge rom = loader.loadCartridge("../roms/donkey_kong.nes"); // draws zeroes instead of sprites
 //    rom.info.memoryMapperId = 0;
 

--- a/src/shaders/blur.frag
+++ b/src/shaders/blur.frag
@@ -13,7 +13,7 @@ const float weight[] = float[] (0.198596,0.175713,0.121703,0.065984,0.028002,0.0
 
 void main()
 {
-    vec2 tex_offset = 1.0 / textureSize(texSampler, 0);
+    vec2 tex_offset = 0.2 / textureSize(texSampler, 0);
     vec2 uv = inTexCoord;
     uv.y = 1 - uv.y;
 


### PR DESCRIPTION
First step in multi-platform support.
The tricky parts here are cmake and conan. Had to force a specific version of Clang for VS 2019 compatibility with conan's build-tool detection. Disable some GCC specific extensions that are not available on VS compiler. Forced VS to use Clang frontend.

Switched from GCC specific byte-alignment pragmas to a more generic syntax supported by both platforms.

Temporarily disabled audio rendering and vsync (as vsync actually works on Windows).

As a bonus, CMake now copies non-compiling dependencies (fonts, shaders, roms) into the build folder, which replaces silly old relative paths that pointed into /src/.

Also had to disable backtrace-install because it was unsupported on Windows.